### PR TITLE
[*] fix error + some new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ A Discord bot that automates the management for Microspacing Vancouver (MSV) eve
 - **`!set_event_number <number>`**
   - **Description**: Manually sets the current event number.
   - **Usage**: `!set_event_number 70`
+
+> Note to self: The StartGG token this bot uses (i.e., `waitlist-bot` in Dantotto profile) was created around October 2024, the token should be updated around August 2025 at the latest by changing the `.env` file in the deployed Ubuntu server and re-running pm2 (`pm2 restart 6 --update-env`).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
+
 # Microspacing Vancouver Discord Bot
 
 > Note: This project was developed during Microsoft Vancouver's 2024 Hackathon!
 
-A Discord bot that automates the management for Microspacing Vancouver (MSV) events.
+A Discord bot that automates the management of Microspacing Vancouver (MSV) events.
 
 ## What the Bot Does
 
-- **Monitors Event Registrations**: Checks the number of entrants for MSV events on Start.gg.
-- **Creates Waitlist Threads**: Automatically creates a new waitlist thread in the MSV Discord server when the entrant cap (32) is reached.
-- **Locks Previous Threads**: Locks the previous waitlist thread to prevent further entries.
-- **Administrator Commands**: Provides commands for admins to control the bot's behavior.
+- **Monitors Event Registrations**: Checks the number of entrants for MSV events on Start.gg using a configurable event URL.
+- **Creates Waitlist Threads**: Automatically creates a new waitlist thread in the MSV Discord server when the entrant cap is reached (default: 32, but configurable).
+- **Locks Previous Threads**: Locks the previous waitlist thread every Tuesday, notifying users with a message that a new one will be created once the next event caps.
+- **Announcements**: Posts an announcement every Wednesday morning, providing registration details and encouraging attendees to bring setups.
+- **Administrator Commands**: Provides commands for admins to control and configure the bot's behavior.
 
 ## Administrator Commands
+
+- **`!set_current_event <url>`**
+  - **Description**: Sets the current event Start.gg URL that the bot will monitor.
+  - **Usage**: `!set_current_event https://www.start.gg/tournament/microspacing-vancouver-77/event/ultimate-singles`
+
+- **`!set_attendee_cap <number>`**
+  - **Description**: Sets the maximum number of entrants for the current event (default: 32).
+  - **Usage**: `!set_attendee_cap 40`
+
+- **`!check_current_event`**
+  - **Description**: Displays the current event details, including URL, attendee cap, and whether the bot’s operations are currently canceled.
+  - **Usage**: `!check_current_event`
 
 - **`!cancel_run`**
   - **Description**: Cancels the bot's operations until resumed.
@@ -21,8 +35,16 @@ A Discord bot that automates the management for Microspacing Vancouver (MSV) eve
   - **Description**: Resumes the bot's operations after a cancellation.
   - **Usage**: `!resume_run`
 
-- **`!set_event_number <number>`**
-  - **Description**: Manually sets the current event number.
-  - **Usage**: `!set_event_number 70`
+## Other Features
 
-> Note to self: The StartGG token this bot uses (i.e., `waitlist-bot` in Dantotto profile) was created around October 2024, the token should be updated around August 2025 at the latest by changing the `.env` file in the deployed Ubuntu server and re-running pm2 (`pm2 restart 6 --update-env`).
+- **Weekly Announcements**: Posts a detailed registration announcement in a dedicated channel every Wednesday morning.
+- **Automatic Thread Management**: Locks previous waitlist threads and creates new ones dynamically based on event registration status.
+- **Fun Additions**: Includes a `!roll_dice` command for entertainment, rolling a random number between 1 and 6.
+
+## Note on Tokens and Deployment
+
+The Start.gg token this bot uses (i.e., `waitlist-bot` in the Dantotto profile) was created around October 2024. The token should be updated around August 2025 at the latest by changing the `.env` file in the deployed Ubuntu server and re-running PM2 with the following command:
+
+```bash
+pm2 restart 6 --update-env
+```

--- a/bot.py
+++ b/bot.py
@@ -21,54 +21,75 @@ intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
 scheduler = AsyncIOScheduler()
 
-INITIAL_EVENT_NUMBER = 69  # Hard-coded starting event number
+DEFAULT_ATTENDEE_CAP = 32
 
 @bot.event
 async def on_ready():
     print(f'Logged in as {bot.user}')
 
-
     # Initialize bot variables
     bot.canceled_this_week = False
     bot.previous_post = None
-    bot.current_event_number = INITIAL_EVENT_NUMBER  # Start at 70 on bot's first run
+    bot.current_event_slug = None
+    bot.attendee_cap = DEFAULT_ATTENDEE_CAP
 
-    # Set up the scheduler to run every Wednesday at 8:30 AM PST
+    # Set up the scheduler to run every Tuesday at 8:30 AM PST for locking previous posts
     pst = pytz.timezone('America/Los_Angeles')
+    scheduler.add_job(
+        lock_previous_post,
+        CronTrigger(day_of_week='tue', hour=8, minute=30, timezone=pst)
+    )
+
+    # Set up the scheduler to run every Wednesday at 8:30 AM PST for announcements and checks
     scheduler.add_job(
         scheduled_task_wrapper,
         CronTrigger(day_of_week='wed', hour=8, minute=30, timezone=pst)
     )
 
-    # Set up the scheduler to run every minute for testing
-    # scheduler.add_job(
-    #     scheduled_task_wrapper,
-    #     CronTrigger(minute='*/1')  # Runs every minute
-    # )
-
-
     scheduler.start()
 
+async def lock_previous_post():
+    if bot.previous_post:
+        await bot.previous_post.edit(locked=True)
+        await bot.previous_post.send("Waitlist locked, new one will be created once the next event caps.")
+        print("Locked the previous waitlist thread.")
+
 async def scheduled_task_wrapper():
-    # Increment the event number
-    bot.current_event_number += 1
-    print(f'Event number incremented to {bot.current_event_number}')
-
-    await check_attendees()
-
-async def check_attendees():
-    # Check if admin has canceled the run for this week
     if bot.canceled_this_week:
         print('Run canceled for this week.')
         return
 
-    channel = bot.get_channel(1193295598166737118) # Hard-coded waitlist channel ID
+    if not bot.current_event_slug:
+        print('No current event slug set.')
+        return
+
+    # Post the announcement
+    announcement_channel = bot.get_channel(1066863301885173800)
+    if announcement_channel:
+        await announcement_channel.send(
+            f"@everyone ~ registration for next week's event is open!\n\n"
+            f"- {bot.attendee_cap} player cap.\n"
+            f"- public reg goes out tomorrow at 8:30AM (if cap isn't hit).\n"
+            f"- for venue access, see: #how-to-get-to-the-venue .\n"
+            f"- **:warning: BRING YOUR NINTENDO SWITCHES (DOCK, CONSOLE, POWER CABLE, AND HDMI) WITH GAME CUBE ADAPTERS :warning:** "
+            f"(running Swiss is dependent on having at least 20 setups; otherwise, we'll do normal Redemption). We've got monitors.\n"
+            f"- if you are trying to register, but we’ve already reached the cap, please drop your StartGG tag "
+            f"(and say if you can bring a setup) at #add-me-to-the-waitlist once it opens. Are you from out-of-region? If so, you have priority in the waitlist!\n\n"
+            f"PS If you can’t bring a full setup, but would still like to contribute, _please bring your GCC adapter_. "
+            f"There are some people that can bring full setups but only play w/ pro cons., so it’s always best to have extras.\n\n"
+            f"https://start.gg/{bot.current_event_slug}"
+        )
+
+    # Check attendees
+    await check_attendees()
+
+async def check_attendees():
+    channel = bot.get_channel(1193295598166737118)  # Hard-coded waitlist channel ID
 
     if channel is None:
         print('Channel not found. Please check the channel ID.')
         return
 
-    # Updated GraphQL query
     query = '''
     query getEventEntrants($slug: String!) {
       event(slug: $slug) {
@@ -86,11 +107,10 @@ async def check_attendees():
 
         attendee_count = 0
 
-        while attendee_count < 32:
+        while attendee_count < bot.attendee_cap:
             try:
-                # Construct variables with the current event number
                 variables = {
-                    "slug": f"tournament/microspacing-vancouver-{bot.current_event_number}/event/ultimate-singles"
+                    "slug": bot.current_event_slug
                 }
 
                 async with session.post(
@@ -100,25 +120,23 @@ async def check_attendees():
                 ) as resp:
                     data = await resp.json()
 
-                    # Check if the event exists
                     if data.get('data') and data['data'].get('event'):
                         attendee_count = data['data']['event']['numEntrants']
                         print(f'Current entrants: {attendee_count}')
                     else:
-                        print(f"Event not found for event number {bot.current_event_number}.")
-                        break  # Exit the loop if the event doesn't exist
+                        print(f"Event not found for slug: {bot.current_event_slug}.")
+                        break
             except Exception as e:
                 print(f'Error fetching data: {e}')
                 await asyncio.sleep(30)
                 continue
 
-            if attendee_count >= 32:
-                # Lock the previous week's post
+            if attendee_count >= bot.attendee_cap:
                 if bot.previous_post:
                     await bot.previous_post.edit(locked=True)
+                    await bot.previous_post.send("Waitlist locked, new one will be created once the next event caps.")
 
-                # Create a new post
-                title = f'Waitlist for MSV#{bot.current_event_number}'
+                title = f'Waitlist for {bot.current_event_slug}'
                 content = (
                     'Answer in the thread if you\'d like to be added to the waitlist!\n\n'
                     'Top 8 of this waitlist get priority registration for next week. '
@@ -126,10 +144,31 @@ async def check_attendees():
                 )
 
                 new_thread = await channel.create_thread(name=title, content=content)
-                bot.previous_post = new_thread.thread  # Update previous_post
+                bot.previous_post = new_thread.thread
                 break
 
             await asyncio.sleep(30)  # Wait for 30 seconds before checking again
+
+@bot.command()
+@commands.has_permissions(administrator=True)
+async def set_current_event(ctx, url: str):
+    bot.current_event_slug = '/'.join(url.split('/')[-4:])  # Extracts the slug from the URL
+    await ctx.send(f'Current event set to: {bot.current_event_slug}')
+
+@bot.command()
+@commands.has_permissions(administrator=True)
+async def set_attendee_cap(ctx, cap: int):
+    bot.attendee_cap = cap
+    await ctx.send(f'Attendee cap set to: {bot.attendee_cap}')
+
+@bot.command()
+async def check_current_event(ctx):
+    await ctx.send(
+        f"Current event details:\n"
+        f"- URL: {bot.current_event_slug or 'Not set'}\n"
+        f"- Attendee cap: {bot.attendee_cap}\n"
+        f"- Run canceled: {bot.canceled_this_week}"
+    )
 
 @bot.command()
 @commands.has_permissions(administrator=True)
@@ -144,9 +183,9 @@ async def resume_run(ctx):
     await ctx.send('The bot has been resumed.')
 
 @bot.command()
-@commands.has_permissions(administrator=True)
-async def set_event_number(ctx, number: int):
-    bot.current_event_number = number
-    await ctx.send(f'Current event number updated to {bot.current_event_number}. Note, next run will apply to {bot.current_event_number + 1}')
+async def roll_dice(ctx):
+    import random
+    result = random.randint(1, 6)
+    await ctx.send(f'🎲 You rolled a {result}!')
 
 bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
-  bot won't just increment from MSV#69 every week now, that was prone to errors. Instead, every week, the TO is just expected to set the URL of the upcoming MSV.
- bot now also posts the registration announcement.
- bot now has a fun `roll_dice` command.
- bot now locks the previous waitlist post on Tuesday instead of Wednesday.